### PR TITLE
Fix compilation errors and move towards a unity build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore the compiled binary
+elem
+

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Makefile for the elem program
 
 # compile the binary
-elem: main.c symbols.c names.c symbols.h names.h
-	gcc main.c names.c symbols.c -o elem
+elem: main.c symbols.c names.c
+	gcc main.c -o elem
 
 # delete the binary
 clean:

--- a/main.c
+++ b/main.c
@@ -11,8 +11,8 @@
 #include <string.h>
 
 // Get the lookup tables of elemental symbols and names
-#include "symbols.h"
-#include "names.h"
+#include "symbols.c"
+#include "names.c"
 
 // Define a boolean type for convenience
 typedef enum {false, true} bool;

--- a/names.h
+++ b/names.h
@@ -1,6 +1,0 @@
-// Declare the array of 119 elemental names that is created in names.c
-
-// Last edited 5/10/16 by Greg Vance
-
-char * names[119];
-

--- a/symbols.h
+++ b/symbols.h
@@ -1,6 +1,0 @@
-// Declare the array of 119 elemental symbols that is created in symbols.c
-
-// Last edited 5/10/16 by Greg Vance
-
-char * symbols[119];
-


### PR DESCRIPTION
Closes #1. The old `elem` code now compiles with `gcc` on WSL, and it seems to run correctly.

In fixing this issue, I've started to move the project towards a "unity build" setup rather than the traditional C design with header files. This is an idea I've been wanting to try for a while, and a small project like `elem` is a good place to do it, seeing as there aren't likely to be any real negative consequences here.